### PR TITLE
Add: options test

### DIFF
--- a/spec/4-options.test.ts
+++ b/spec/4-options.test.ts
@@ -1,0 +1,51 @@
+import { expect } from 'chai';
+
+import render from '../lib/render';
+
+describe('options', () => {
+  it('should render a tag with a variable in text', () => {
+    const template = 'h1: "@{title}"\n';
+    const result = render(template, { title: 'Object-like Template' });
+
+    expect(result).to.equal('<h1>Object-like Template</h1>');
+  });
+
+  it('should render a tag with a variable in property', () => {
+    const template = 'h1(class="@{className}")\n';
+    const result = render(template, { className: 'red-line' });
+
+    expect(result).to.equal('<h1 class="red-line"></h1>');
+  });
+
+  it('should render a tag with variables', () => {
+    const template = 'h1(class="@{className}"): "@{title}"\n';
+    const result = render(template, { title: 'Object-like Template', className: 'red-line' });
+
+    expect(result).to.equal('<h1 class="red-line">Object-like Template</h1>');
+  });
+
+  it('should throw a syntax error when not close variable block', () => {
+    const template = 'h1(class="@{className")\n';
+
+    expect(render(template, { className: 'red-line' })).to.throw(SyntaxError, 'Unclosed variable');
+  });
+
+  it('should render a tag with default variable', () => {
+    const template = 'h1: "@{title = "title"}\n';
+    const result = render(template);
+
+    expect(render(result)).to.equal('<h1>title</h1>');
+  });
+
+  it('should throw a reference error when use variable without options', () => {
+    const template = 'h1(class="@{className}")\n';
+
+    expect(render(template)).to.throw(ReferenceError, 'options is required if you want variable');
+  });
+
+  it('should throw a reference error when use undefined variable', () => {
+    const template = 'h1(class="@{className}")\n';
+
+    expect(render(template, { class: 'red-line' })).to.throw(ReferenceError, '"className" is undefined');
+  });
+});


### PR DESCRIPTION
- 부분 템플릿의 적용은 기본 테스트에서 할 것이 아닌 것으로 생각됨
- 존재하는 파일을 불러와서 render하는 테스트 추가 필요
- 기본 테스트에서 사용하는 함수 명(render)를 convert 등의 좀 더 작은 단위로 바꿔야 함