### PR TITLE
Convert pass

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -29,6 +29,8 @@
       }
     ],
     "linebreak-style": "off",
-    "no-shadow": "off"
+    "no-shadow": "off",
+    "no-template-curly-in-string": "off",
+    "no-continue": "off",
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -30,7 +30,6 @@
     ],
     "linebreak-style": "off",
     "no-shadow": "off",
-    "no-template-curly-in-string": "off",
-    "no-continue": "off",
+    "no-continue": "off"
   }
 }

--- a/lib/constant/state.ts
+++ b/lib/constant/state.ts
@@ -5,6 +5,4 @@ const STATE = {
   IS_VALUE: 'isValue',
 } as const;
 
-// type STATE = typeof STATE[keyof typeof STATE];
-
 export default STATE;

--- a/lib/convert.ts
+++ b/lib/convert.ts
@@ -10,17 +10,19 @@ type Attribute = [string, string];
 interface Tag {
   name: string,
   attributes: Attribute[],
+  inBlockTags: Tag[],
 }
 
 export function convert(template: string, options?: Options): string {
   const unClosedTags: Tag[] = [];
-  const initialTag: Tag = {
-    name: '',
-    attributes: [],
-  };
+  const blockTags: Tag[] = [];
 
   let state: string = STATE.IS_TAG_NAME;
-  let tag: Tag = { ...initialTag };
+  let tag: Tag = {
+    name: '',
+    attributes: [],
+    inBlockTags: [],
+  };
   let attribute: Attribute = ['', ''];
   let currentStr = '';
   let result = '';
@@ -46,18 +48,27 @@ export function convert(template: string, options?: Options): string {
     currentStr = '';
   }
 
+  function resetTag() {
+    tag = {
+      name: '',
+      attributes: [],
+      inBlockTags: [],
+    };
+  }
+
   function openTag() {
     const { name, attributes } = tag;
-    const attributesStr = attributes.map(([name, value]) => `${name}="${value}"`).join('');
+    const attributesStr = attributes.map(([name, value]) => `${name}="${value}"`).join(' ');
+    const currentBlockTag = blockTags[blockTags.length - 1];
 
     if (singletons.has(name)) {
       result += attributesStr ? `<${name} ${attributesStr} />` : `<${name} />`;
     } else {
       result += attributesStr ? `<${name} ${attributesStr}>` : `<${name}>`;
-      unClosedTags.push(tag);
+      (blockTags.length ? currentBlockTag.inBlockTags : unClosedTags).push(tag);
     }
 
-    tag = { ...initialTag };
+    resetTag();
   }
 
   function addValue() {
@@ -65,14 +76,49 @@ export function convert(template: string, options?: Options): string {
     currentStr = '';
   }
 
-  function closeCurrentTag() {
-    const closeTag = unClosedTags.pop();
+  function closeCurrentTag(isBlockTag? : true) {
+    const currentBlockTag = blockTags[blockTags.length - 1];
+    const currentUncloseTags = blockTags.length ? currentBlockTag.inBlockTags : unClosedTags;
+    const closeTag = (isBlockTag ? blockTags : currentUncloseTags).pop();
+
     result += `</${closeTag?.name}>`;
   }
 
   function closeTags() {
-    const closeTags = unClosedTags.map(({ name }) => `</${name}>`);
+    const currentBlockTag = blockTags[blockTags.length - 1];
+    const closeTags = (blockTags.length ? currentBlockTag.inBlockTags : unClosedTags).map(({ name }) => `</${name}>`);
     result += closeTags.reverse().join('');
+
+    if (blockTags.length) {
+      currentBlockTag.inBlockTags = [];
+    }
+  }
+
+  function closeBlock() {
+    const currentBlockTag = blockTags[blockTags.length - 1];
+
+    if (currentStr || state === STATE.IS_TAG_NAME) {
+      setTagName();
+    }
+
+    if (tag.name) {
+      openTag();
+    }
+
+    if (currentBlockTag.inBlockTags.length) {
+      closeTags();
+    }
+
+    closeCurrentTag(true);
+    blockTags.pop();
+  }
+
+  function openBlock() {
+    const currentTag = unClosedTags.pop();
+
+    if (currentTag) {
+      blockTags.push(currentTag);
+    }
   }
 
   function handleTagName(char: string, prevChar: string) {
@@ -110,10 +156,16 @@ export function convert(template: string, options?: Options): string {
           openTag();
         }
 
-        if (prevChar !== ':' && prevChar !== ',') {
+        if (prevChar !== ':' && prevChar !== ',' && prevChar !== '{') {
           closeTags();
         }
 
+        break;
+      case '{':
+        openBlock();
+        break;
+      case '}':
+        closeBlock();
         break;
       default:
         currentStr += char;
@@ -181,6 +233,10 @@ export function convert(template: string, options?: Options): string {
     }
   }
 
+  if (currentStr || state === STATE.IS_TAG_NAME) {
+    setTagName();
+  }
+
   if (tag.name) {
     openTag();
   }
@@ -191,6 +247,10 @@ export function convert(template: string, options?: Options): string {
 
   if (state === STATE.IS_VALUE) {
     throw new SyntaxError('Text has to be in double quotes');
+  }
+
+  if (blockTags.length) {
+    throw new SyntaxError('Unclosed Block (need “}”)');
   }
 
   return result;

--- a/spec/1-convert.test.ts
+++ b/spec/1-convert.test.ts
@@ -109,7 +109,7 @@ describe('multiple tags', () => {
 });
 
 describe('block tags', () => {
-  it('should not tag before "{" until "}', () => {
+  it('should not close tag before "{" until "}', () => {
     const template = 'body: {\n  section: article, article \n  section: article}';
     const result = convert(template);
 

--- a/spec/1-convert.test.ts
+++ b/spec/1-convert.test.ts
@@ -135,48 +135,50 @@ describe('block tags', () => {
 
 describe('options', () => {
   it('should convert a tag with a variable in text', () => {
-    const template = 'h1: @{title}\n';
+    const template = 'h1: "@{title}"\n';
     const result = convert(template, { title: 'Object-like Template' });
 
     expect(result).to.equal('<h1>Object-like Template</h1>');
   });
 
   it('should convert a tag with a variable in property', () => {
-    const template = 'h1(class=@{className})\n';
+    const template = 'h1(class="@{className}")\n';
     const result = convert(template, { className: 'red-line' });
 
     expect(result).to.equal('<h1 class="red-line"></h1>');
   });
 
   it('should convert a tag with variables', () => {
-    const template = 'h1(class=@{className}): @{title}\n';
+    const template = 'h1(class="@{className}"): "@{title}"\n';
     const result = convert(template, { title: 'Object-like Template', className: 'red-line' });
 
     expect(result).to.equal('<h1 class="red-line">Object-like Template</h1>');
   });
 
-  it('should throw a syntax error when not close variable block', () => {
-    const template = 'h1(class=@{className)\n';
-
-    expect(() => convert(template, { className: 'red-line' })).to.throw(SyntaxError, 'Unclosed variable');
-  });
-
   it('should convert a tag with default variable', () => {
-    const template = 'h1: @{title = "title"}\n';
+    const template = 'h1: "@{title = "title"}"\n';
     const result = convert(template);
 
-    expect(() => convert(result)).to.equal('<h1>title</h1>');
+    expect(result).to.equal('<h1>title</h1>');
   });
 
-  it('should throw a reference error when use variable without options', () => {
-    const template = 'h1(class=@{className})\n';
+  it('should convert variable to blank string without options', () => {
+    const template = 'h1(class="@{className}")\n';
+    const result = convert(template);
 
-    expect(() => convert(template)).to.throw(ReferenceError, 'options is required');
+    expect(result).to.equal('<h1 class=""></h1>');
   });
 
-  it('should throw a reference error when use undefined variable', () => {
-    const template = 'h1(class=@{className})\n';
+  it('should convert variable when use undefined variable', () => {
+    const template = 'h1(class="@{className}")\n';
+    const result = convert(template);
 
-    expect(() => convert(template, { class: 'red-line' })).to.throw(ReferenceError, '"className" is undefined');
+    expect(result).to.equal('<h1 class=""></h1>');
+  });
+
+  it('should throw a syntax error when not close variable block', () => {
+    const template = 'h1(class="@{className")\n';
+
+    expect(() => convert(template, { className: 'red-line' })).to.throw(SyntaxError, 'Unclosed variable');
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,6 @@
     "target": "esnext",
     "declaration": true,
     "outDir": "/dist",
-    "strict": true,
+    "strict": true
   }
 }


### PR DESCRIPTION
Close #5 
- block tags
- options

변경 사항
- 변수(options)는 큰 따옴표 안에서 사용하는 것으로 바꿈
- 정의되지 않은 변수는 빈 문자열로 대체

생각해야 할 사항
- "@{"을 일반 문자열로 사용할 때를 구분해야 함.
- handleKey의 중첩 조건문을 줄일 방법 생각해보기.