### PR TITLE
Add: text or singleton and siblings case

### DIFF
--- a/lib/convert.ts
+++ b/lib/convert.ts
@@ -18,6 +18,11 @@ export function convert(template: string, options?: Options): string {
 
   let unClosedTags: Tag[] = [];
   let state: string = STATE.IS_TAG_NAME;
+  let prevTag: Tag = {
+    name: '',
+    attributes: [],
+    inBlockTags: [],
+  };
   let tag: Tag = {
     name: '',
     attributes: [],
@@ -60,6 +65,13 @@ export function convert(template: string, options?: Options): string {
 
   function openTag() {
     const { name, attributes } = tag;
+
+    prevTag = tag;
+
+    if (!name) {
+      return;
+    }
+
     const attributesStr = attributes.map(([name, value]) => `${name}="${value}"`).join(' ');
     const currentBlockTag = blockTags[blockTags.length - 1];
 
@@ -76,11 +88,17 @@ export function convert(template: string, options?: Options): string {
   function addValue() {
     result += currentStr;
     currentStr = '';
+    openTag();
   }
 
   function closeCurrentTag(isBlockTag? : true) {
     const currentBlockTag = blockTags[blockTags.length - 1];
     const currentUncloseTags = blockTags.length ? currentBlockTag.inBlockTags : unClosedTags;
+
+    if (!isBlockTag && prevTag !== currentUncloseTags[currentUncloseTags.length - 1]) {
+      return;
+    }
+
     const closeTag = (isBlockTag ? blockTags : currentUncloseTags).pop();
 
     result += `</${closeTag?.name}>`;

--- a/spec/1-convert.test.ts
+++ b/spec/1-convert.test.ts
@@ -106,6 +106,30 @@ describe('multiple tags', () => {
       + '</html>',
     );
   });
+
+  it('should convert parent and singleton tag and sibling tag without line-break', () => {
+    const template = 'body: input(type="text"), p: "I\'m paragraph"\n';
+    const result = convert(template);
+
+    expect(result).to.equal(
+      '<body>'
+        + '<input type="text" />'
+        + '<p>I\'m paragraph</p>'
+      + '</body>',
+    );
+  });
+
+  it('should convert parent and text and child tag without line-break', () => {
+    const template = 'body: "I\'m text", p: "I\'m paragraph"\n';
+    const result = convert(template);
+
+    expect(result).to.equal(
+      '<body>'
+        + 'I\'m text'
+        + '<p>I\'m paragraph</p>'
+      + '</body>',
+    );
+  });
 });
 
 describe('block tags', () => {

--- a/spec/views/articleWithOption.olv
+++ b/spec/views/articleWithOption.olv
@@ -1,3 +1,4 @@
-article:
-  h1: "@{title}",
+article: {
+  h1: "@{title}"
   p: "@{content}"
+}


### PR DESCRIPTION
- 텍스트나 닫힘 태그가 없는 태그 뒤에 ","를 사용했을 시 부모 태그가 닫히는 현상을 수정하였습니다.